### PR TITLE
Fix expression body crash

### DIFF
--- a/mpapt-runtime/src/main/java/de/jensklingenberg/mpapt/extension/DeclarationCheckerImpl.kt
+++ b/mpapt-runtime/src/main/java/de/jensklingenberg/mpapt/extension/DeclarationCheckerImpl.kt
@@ -223,7 +223,6 @@ class DeclarationCheckerImpl(val processor: AbstractProcessor) : DeclarationChec
                         .bodyExpression
                         ?.blockExpressionsOrSingle()
                         ?.filterIsInstance<KtAnnotatedExpression>()
-                        ?.filterIsInstance<KtAnnotatedExpression>()
                         ?.toList()
 
         annotatedExpressions?.forEach { ktannotedexp ->

--- a/mpapt-runtime/src/main/java/de/jensklingenberg/mpapt/extension/DeclarationCheckerImpl.kt
+++ b/mpapt-runtime/src/main/java/de/jensklingenberg/mpapt/extension/DeclarationCheckerImpl.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.blockExpressionsOrSingle
 import org.jetbrains.kotlin.resolve.BindingTraceContext
 import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
 import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
@@ -217,20 +218,13 @@ class DeclarationCheckerImpl(val processor: AbstractProcessor) : DeclarationChec
 
     private fun checkAnnotatedExpression(declaration: KtDeclaration, context: DeclarationCheckerContext, annotationName: String, roundEnvironment: RoundEnvironment, descriptor: SimpleFunctionDescriptor) {
 
-        /**
-         * We need to distinguish here between native and other platforms because the native compiler
-         * was always crashing when "...bodyExpression?.children?" was called.
-         * TODO: Check if versions >1.3.41 are still crashing
-         */
-
-        val annotatedExpressions = when (processor.activeTargetPlatform.first().platformName) {
-            KotlinPlatformValues.NATIVE -> {
-                ((declaration as KtNamedFunction).bodyExpression as KtBlockExpression).statements.filterIsInstance<KtAnnotatedExpression>()
-            }
-            else -> {
-                (declaration as KtNamedFunction).bodyExpression?.children?.filterIsInstance<KtAnnotatedExpression>()
-            }
-        }
+        val annotatedExpressions =
+                (declaration as KtNamedFunction)
+                        .bodyExpression
+                        ?.blockExpressionsOrSingle()
+                        ?.filterIsInstance<KtAnnotatedExpression>()
+                        ?.filterIsInstance<KtAnnotatedExpression>()
+                        ?.toList()
 
         annotatedExpressions?.forEach { ktannotedexp ->
             ktannotedexp.findAnnotation(context.trace as BindingTraceContext, annotationName)?.let {


### PR DESCRIPTION
This fixes a crash when checking annotated expressions which don't have an expressionBlockBody.

Crash occurred during analysis of functions with expression body like: `fun foo() = 1 + 1`.

Fixed by leveraging a utility function (`blockExpressionsOrSingle`) which iterates and collects block expression statements as well as expressionStatements into a Sequence.